### PR TITLE
Fixed 'invalidIPv6' regex

### DIFF
--- a/lib/IPParser.js
+++ b/lib/IPParser.js
@@ -24,7 +24,7 @@ var repeat = function(c,l){
 	while(i++ < l)str+=c;
 	return str;
 }
-ipp.invalidIPv6 = /[^0-9a-f\:]/i;
+ipp.invalidIPv6 = /[^0-9A-Fa-f\:]/i;
 ipp.parseIPv6 = function(ipstr){
 	if(ipp.invalidIPv6.test(ipstr)){
 		throw new Error("Invalid IPv6 address");


### PR DESCRIPTION
**Sensiblity** : Medium

**Size** : Small

**Assigners** : @EaterOfCode 

**What's it do?** : 

Fixed the IPParser 'invalidIPv6' regex to allow also uppercase. This fix is base on:

https://tools.ietf.org/html/rfc5952#section-2.3

**Where to start reviewing it?** : lib/IPParser.js