### PR TITLE
[Security] Update dependencies

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+/test/data/

--- a/lib/IPAddress.js
+++ b/lib/IPAddress.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var IPv6 = require('ip-address').v6;
-var IPv4 = require('ip-address').v4;
+var Address6 = require('ip-address').Address6;
+var Address4 = require('ip-address').Address4;
 
 exports.parseIPv4 = function parseIPv4(ip) {
-    var v4Address = new IPv4.Address(ip);
+    var v4Address = new Address4(ip);
     if (!v4Address.isValid()) {
         throw new Error("Invalid IPv4 address");
     }
@@ -12,7 +12,7 @@ exports.parseIPv4 = function parseIPv4(ip) {
 };
 
 exports.parseIPv6 = function parseIPv6(ip) {
-    var v6Address = new IPv6.Address(ip);
+    var v6Address = new Address6(ip);
     if (!v6Address.isValid()) {
         throw new Error("Invalid IPv6 address");
     }

--- a/package.json
+++ b/package.json
@@ -37,13 +37,13 @@
     },
     "dependencies": {
         "big-integer": ">=1.1.5",
-        "ip-address": "4.0.0"
+        "ip-address": "^5.8.6"
     },
     "devDependencies": {
-        "istanbul": "^0.3.13",
-        "jshint": "2.4.2",
-        "path": "^0.11.14",
-        "scotch-tape": "0.2.0"
+        "istanbul": "^0.4.5",
+        "jshint": "^2.9.4",
+        "path": "^0.12.7",
+        "scotch-tape": "^0.2.1"
     },
     "scripts": {
         "cover": "istanbul cover --report cobertura --print detail tape -- test/test.js",


### PR DESCRIPTION
Update `ip-address` to fix https://snyk.io/vuln/npm:minimatch:20160620

This also changes the use of `ip-address` so everything still works